### PR TITLE
Patch 2

### DIFF
--- a/lib/launcher/launcher.js
+++ b/lib/launcher/launcher.js
@@ -23,7 +23,7 @@ class Launcher extends appolo.Launcher {
             urlParser: "fast",
             viewExt: "html",
             viewEngine: null,
-            viewFolder: "/server/views"
+            viewFolder: "server/views"
         };
     }
     async launch(config, callback) {

--- a/lib/launcher/launcher.ts
+++ b/lib/launcher/launcher.ts
@@ -29,7 +29,7 @@ export class Launcher extends appolo.Launcher {
         urlParser: "fast",
         viewExt: "html",
         viewEngine: null,
-        viewFolder: "/server/views"
+        viewFolder: "server/views"
     };
 
     public async launch(config?: IOptions, callback?: (err?: any,app?:App) => void): Promise<App> {


### PR DESCRIPTION
When the `render` function [looks for a file to render](https://github.com/shmoop207/appolo-http/blob/master/lib/app/view.ts#L38), it uses `path.resolve`. Since `viewFolder` started with a back slash, it caused the path to start at `/server` instead of the real root folder.